### PR TITLE
Linuxserver-ise it.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN \
 	--no-install-recommends \
 	vlc-nox && \
  apt-get install -y \
-	avahi \
+	avahi-daemon \
 	bzip2 \
 	dbus && \
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,44 @@
 FROM lsiobase/xenial
 MAINTAINER madcatsu
 
-# AirVideo Server HD version
+# package versions
 ARG AVSERVERHD_VERSION="2.2.3"
 
-# Set necessary build attributes
-ARG DEBIAN_FRONTEND="noninteractive"
-ARG DEPENDENCIES="\
-  wget \
-  bzip2 \
-  avahi-daemon \
-  dbus"
+# global environment settings
 ENV LANG C.UTF-8
 
-# Install required packages
+# build environment settings
+ARG DEBIAN_FRONTEND="noninteractive"
+
+# install packages
 RUN \
-  apt-get update && \
-  apt-get install -y --no-install-recommends vlc-nox && \
-  apt-get install -y $DEPENDENCIES && \
+ apt-get update && \
+ apt-get install -y \
+	--no-install-recommends \
+	vlc-nox && \
+ apt-get install -y \
+	avahi \
+	bzip2 \
+	dbus && \
 
-# Create fetch binary and unpack
-  wget -qO \
-    /tmp/avhd-pkg.tar.bz2 -L \
-    "https://s3.amazonaws.com/AirVideoHD/Download/AirVideoServerHD-${AVSERVERHD_VERSION}.tar.bz2" && \
-  tar xjf /tmp/avhd-pkg.tar.bz2 -C /opt && \
+# install airvideo
+ mkdir -p \
+	/opt/airvideohd && \
+ curl -o \
+ /tmp/airvideo.tar.bz2 -L \
+	"https://s3.amazonaws.com/AirVideoHD/Download/AirVideoServerHD-${AVSERVERHD_VERSION}.tar.bz2" && \
+ tar xjf \
+ /tmp/airvideo.tar.bz2 -C \
+	/opt/airvideohd --strip-components=1 && \
 
-# Clean up
-  apt-get purge -y wget bzip2 && \
-  apt-get autoremove -y && \
-  apt-get clean -y && \
-  rm -rf /var/lib/apt/lists/* /tmp/*
+# cleanup
+ rm -rf \
+	/tmp/* \
+	/var/lib/apt/lists/*
 
-# Add local defaults
+# copy local files
 COPY /root /
 
-# Setup ports and volumes for mapping
+# ports and volumes
 EXPOSE 45633 5353/udp
-VOLUME /config /transcode /multimedia
+VOLUME /config /media /transcode

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Air Video HD allows you to watch videos streamed instantly from your computer on
 docker create --name=<container name> \
 -e PUID=<host user ID> \
 -e PGID=<host group ID> \
--v </path/to/your/videos>:/multimedia \
+-v </path/to/your/videos>:/media \
 -v </path/to/your/persistent/config/folder>:/config \
 -v </path/to/your/scratch/disk/for/transcoding>:/transcode \
 -p 5353:5353/udp \
@@ -52,7 +52,7 @@ Edit Server.properties and replace the Sharing section with the following entrie
 
 # First shared folder
 sharedFolders1.displayName = Movies
-sharedFolders1.path = /multimedia/Movies
+sharedFolders1.path = /media/Movies
 
 # Second shared folder
 sharedFolders2.displayName = TV Shows
@@ -76,7 +76,7 @@ Edit Server.properties and replace the Sharing section with the following entrie
 
 # First shared folder
 sharedFolders1.displayName = Movies
-sharedFolders1.path = /multimedia/Movies
+sharedFolders1.path = /media/Movies
 
 # Second shared folder
 sharedFolders2.displayName = TV Shows
@@ -100,7 +100,7 @@ Edit the Server.properties and replace the Sharing section with the following en
 
 # First shared folder
 sharedFolders1.displayName = Movies
-sharedFolders1.path = /multimedia/Movies
+sharedFolders1.path = /media/Movies
 
 # Second shared folder
 sharedFolders2.displayName = TV Shows
@@ -138,7 +138,7 @@ userAccounts3.password = potter <---- change this!
 We'd like to improve this container further so we've listed here a couple of future Roadmap items under consideration:
 
 + Version specification - Choose the latest or a specific numbered version of the Air Video Server HD binary to run
-+ Share creation via ENV - Setup one or more multimedia folders with open or limited access using environment vars
++ Share creation via ENV - Setup one or more media folders with open or limited access using environment vars
 
 #### Thanks
 This work is largely based off the existing projects put together by the Linuxserver.io guys. Go buy them a beer!

--- a/root/defaults/Server.properties
+++ b/root/defaults/Server.properties
@@ -24,10 +24,10 @@ VLCLibraryPath = /usr/lib/
 #VLCLibraryPath = /usr/lib64/
 
 # logs path
-#logsPath = ~/.AirVideoServerHD/Logs
+logsPath = /config/log
 
 # application data path
-#applicationDataPath = ~/.AirVideoServerHD/ApplicationData
+applicationDataPath = /config/airvideohd
 
 # conversion folder path
 conversionFolderPath = /transcode
@@ -40,12 +40,12 @@ computerName = AirVideoServerHD
 #
 
 # First shared folder
-sharedFolders1.displayName = Multimedia
-sharedFolders1.path = /multimedia
+sharedFolders1.displayName = Media
+sharedFolders1.path = /media
 
 # second shared folder
-# sharedFolders2.displayName = TV Shows
-# sharedFolders2.path = ~/TVShows
+# sharedFolders2.displayName = TV-Shows
+# sharedFolders2.path = /tv-shows
 
 # multiuser mode (true/false)
 multiUserMode = false

--- a/root/etc/cont-init.d/40-config
+++ b/root/etc/cont-init.d/40-config
@@ -1,15 +1,19 @@
 #!/usr/bin/with-contenv bash
 
-# Copy default config in place and match
-# AirVideo Server Computer Name with Container name
+# copy config
 [[ ! -e /config/Server.properties ]] && \
-  sed -i -e "s/computerName\s*=\s*AirVideoServerHD/computerName = $HOSTNAME/g" /defaults/Server.properties
-  cp /defaults/Server.properties /config/Server.properties
+	cp /defaults/Server.properties /config/Server.properties
 
-# Set permissions
+
+# configure hostname
+sed -i -e \
+	"s/computerName\s*=\s*AirVideoServerHD/computerName = $HOSTNAME/g" \
+	/config/Server.properties
+
+# permissions
 chown -R abc:abc \
-  /config /transcode /opt/AirVideoServerHD
-
-# Make sure binary is executable
+	/config \
+	/opt/airvideohd \
+	/transcode
 chmod +x \
-  /opt/AirVideoServerHD
+	/opt/airvideohd/AirVideoServerHD

--- a/root/etc/services.d/AirVideoServerHD/run
+++ b/root/etc/services.d/AirVideoServerHD/run
@@ -1,4 +1,0 @@
-#!/usr/bin/with-contenv bash
-umask 022
-
-exec s6-setuidgid abc /opt/AirVideoServerHD --config=/config/Server.properties

--- a/root/etc/services.d/airvideo/run
+++ b/root/etc/services.d/airvideo/run
@@ -1,0 +1,6 @@
+#!/usr/bin/with-contenv bash
+umask 022
+
+exec \
+	s6-setuidgid abc /opt/airvideohd/AirVideoServerHD \
+	--config=/config/Server.properties


### PR DESCRIPTION
+ Bring it up to more inhouse style.
+ Use curl instead of wget , curl is already installed in the baseimage.
+ don't uninstall bzip2, negligible increase in final image size.
+ unpack airvideo to a known location rather than /opt , if they change the archive at any time will break the container
+ sed the hostname in to the copy of server.properties in /config rather than the /defaults one, 
 change always made whilst keeping pristine copy in /defaults.
+ change server.properties to put appdata and logs in normal folders off of config rather than hidden folders.
+ use /media in place of /multimedia